### PR TITLE
Amendment in Channel Unit definition

### DIFF
--- a/GeoReservoirOntology.owl
+++ b/GeoReservoirOntology.owl
@@ -628,7 +628,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <IRI>#UFRGS:GeoReservoirOntology_channel_unit</IRI>
-        <Literal xml:lang="en">A Depositional Unit consisting of some Channel Surface and some Sediment or Sedimentary Rock that fills it (McHargue et al, 2011).</Literal>
+        <Literal xml:lang="en">An elongated Depositional Unit having some Channel Surface as its boundary and constituted by some Sediment or Sedimentary Rock that fills it (McHargue et al., 2011).</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -4,9 +4,9 @@
     <uri id="User Entered Import Resolution" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology/1.0" uri="imports/GeoCoreOntology.owl"/>
     <uri id="Imports Wizard Entry" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology" uri="imports/GeoCoreOntology.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1614608104854" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology" uri="imports/GeoCoreOntology.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1614608104854" name="https://www.inf.ufrgs.br/bdi/ontologies/geologicalspatialrelationsontology" uri="imports/GeologicalSpatialRelationsOntology.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1614608104854" name="https://www.inf.ufrgs.br/bdi/ontologies/georeservoirontology" uri="GeoReservoirOntology.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1614608104854" name="https://www.inf.ufrgs.br/bdi/ontologies/karoochannelleveecasestudy" uri="KarooChannelLeveeCaseStudy.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology" uri="imports/GeoCoreOntology.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/geologicalspatialrelationsontology" uri="imports/GeologicalSpatialRelationsOntology.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/georeservoirontology" uri="GeoReservoirOntology.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/karoochannelleveecasestudy" uri="KarooChannelLeveeCaseStudy.owl"/>
     </group>
 </catalog>


### PR DESCRIPTION
- Making clear in the definition that Channel Unit must have a Channel Surface as its boundary. Before this change, it could be misunderstood that Channel Unit has Channel Surface as a mereological part, which is not correct.