### PR TITLE
Levee Unit and Overbank Unit are actually anti-rigid

### DIFF
--- a/GeoReservoirOntology.owl
+++ b/GeoReservoirOntology.owl
@@ -783,7 +783,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="#UFRGS:GeoReservoirOntology_metaproperties"/>
         <IRI>#UFRGS:GeoReservoirOntology_levee_unit</IRI>
-        <Literal>R+ I+ O- U+ ED-</Literal>
+        <Literal>R~ I+ O- U+ ED-</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -879,7 +879,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="#UFRGS:GeoReservoirOntology_metaproperties"/>
         <IRI>#UFRGS:GeoReservoirOntology_overbank_unit</IRI>
-        <Literal>R+ I+ O- U+ ED-</Literal>
+        <Literal>R~ I+ O- U+ ED-</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000115"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -4,9 +4,9 @@
     <uri id="User Entered Import Resolution" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology/1.0" uri="imports/GeoCoreOntology.owl"/>
     <uri id="Imports Wizard Entry" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology" uri="imports/GeoCoreOntology.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology" uri="imports/GeoCoreOntology.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/geologicalspatialrelationsontology" uri="imports/GeologicalSpatialRelationsOntology.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/georeservoirontology" uri="GeoReservoirOntology.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1614722687389" name="https://www.inf.ufrgs.br/bdi/ontologies/karoochannelleveecasestudy" uri="KarooChannelLeveeCaseStudy.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1615939950029" name="https://www.inf.ufrgs.br/bdi/ontologies/geocoreontology" uri="imports/GeoCoreOntology.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1615939950029" name="https://www.inf.ufrgs.br/bdi/ontologies/geologicalspatialrelationsontology" uri="imports/GeologicalSpatialRelationsOntology.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1615939950029" name="https://www.inf.ufrgs.br/bdi/ontologies/georeservoirontology" uri="GeoReservoirOntology.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1615939950029" name="https://www.inf.ufrgs.br/bdi/ontologies/karoochannelleveecasestudy" uri="KarooChannelLeveeCaseStudy.owl"/>
     </group>
 </catalog>


### PR DESCRIPTION
Because the relation with Channel Unit that the terms bring is not essential to the instances. If the associated channel never existed, these units are not Levee/Overbank Unit.